### PR TITLE
Fabric 1.16 snapshots temp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ eclipse/
 .classpath
 .project
 build.number
+/run/

--- a/src/main/java/fi/dy/masa/tweakeroo/config/FeatureToggle.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/config/FeatureToggle.java
@@ -281,7 +281,7 @@ public enum FeatureToggle implements IHotkeyTogglable, IConfigNotifiable<IConfig
         {
             if (element.isJsonPrimitive())
             {
-                this.valueBoolean = element.getAsBoolean();
+                this.setBooleanValue(element.getAsBoolean());
             }
             else
             {

--- a/src/main/java/fi/dy/masa/tweakeroo/config/FeatureToggle.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/config/FeatureToggle.java
@@ -87,7 +87,8 @@ public enum FeatureToggle implements IHotkeyTogglable, IConfigNotifiable<IConfig
     TWEAK_TAB_COMPLETE_COORDINATE   ("tweakTabCompleteCoordinate",          false, "",    "If enabled, then tab-completing coordinates while not\nlooking at a block, will use the player's position\ninstead of adding the ~ character."),
     TWEAK_TOOL_SWITCH               ("tweakToolSwitch",                     false, "",    "Enables automatically switching to an effective tool for the targeted block"),
     TWEAK_Y_MIRROR                  ("tweakYMirror",                        false, "",    "Mirrors the targeted y-position within the block bounds.\nThis is basically for placing slabs or stairs\nin the opposite top/bottom state from normal,\nif you have to place them against another slab for example."),
-    TWEAK_ZOOM                      ("tweakZoom",                           false, "",    KeybindSettings.INGAME_BOTH, "Enables using the zoom hotkey to, well, zoom in");
+    TWEAK_ZOOM                      ("tweakZoom",                           false, "",    KeybindSettings.INGAME_BOTH, "Enables using the zoom hotkey to, well, zoom in"),
+    TWEAK_THIRDPERSON_INVERT        ("tweakThirdpersonInvert",              false, "",    KeybindSettings.INGAME_BOTH, "Inverts the movement keys when using the backwards-facing third person camera.");
 
     private final String name;
     private final String comment;

--- a/src/main/java/fi/dy/masa/tweakeroo/config/FeatureToggle.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/config/FeatureToggle.java
@@ -17,7 +17,7 @@ import fi.dy.masa.tweakeroo.Tweakeroo;
 
 public enum FeatureToggle implements IHotkeyTogglable, IConfigNotifiable<IConfigBoolean>
 {
-    CARPET_ACCURATE_PLACEMENT_PROTOCOL ("carpetAccuratePlacementProtocol",  false, "",    "If enabled, then the Flexible Block Placement and the\nAccurate Block Placement use the protocol implemented\nin the recent carpet mod versions", "Carpet protocol Accurate Placement"),
+    CARPET_ACCURATE_PLACEMENT_PROTOCOL ("carpetAccuratePlacementProtocol",  false, "",    "If enabled, then the Flexible Block Placement and the\nAccurate Block Placement use the protocol implemented\nin the recent carpet mod versions.\nRequires either Servux or Carpet-Extra with the accurateBlockPlacement rule enabled on the server.", "Carpet protocol Accurate Placement"),
     FAST_PLACEMENT_REMEMBER_ALWAYS  ("fastPlacementRememberOrientation",    true, "",     "If enabled, then the fast placement mode will always remember\nthe orientation of the first block you place.\nWithout this, the orientation will only be remembered\nwith the flexible placement enabled and active.", "Fast Placement Remember Orientation"),
     REMEMBER_FLEXIBLE               ("rememberFlexibleFromClick",           true, "",     "If enabled, then the flexible block placement status\nwill be remembered from the first placed block,\nas long as the use key is held down.", "Remember Flexible Orientation From First Click"),
     TWEAK_ACCURATE_BLOCK_PLACEMENT  ("tweakAccurateBlockPlacement",         false, "",    "Enables a simpler version of Flexible placement, similar to\nthe Carpet mod, so basically either facing into or out\nfrom the block face clicked on."),

--- a/src/main/java/fi/dy/masa/tweakeroo/event/WorldLoadListener.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/event/WorldLoadListener.java
@@ -1,6 +1,8 @@
 package fi.dy.masa.tweakeroo.event;
 
 import javax.annotation.Nullable;
+
+import fi.dy.masa.tweakeroo.config.Configs;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.world.ClientWorld;
 import fi.dy.masa.malilib.interfaces.IWorldLoadListener;
@@ -14,5 +16,10 @@ public class WorldLoadListener implements IWorldLoadListener
         // Always disable the Free Camera mode when leaving the world or switching dimensions
         FeatureToggle.TWEAK_FREE_CAMERA.setBooleanValue(false);
         FeatureToggle.TWEAK_FREE_CAMERA_MOTION.setBooleanValue(false);
+
+        // Quick and dirty fix to ensure IValueChangeCallback using callbacks are called.
+        FeatureToggle.TWEAK_GAMMA_OVERRIDE.onValueChanged();
+        Configs.Disable.DISABLE_SLIME_BLOCK_SLOWDOWN.onValueChanged();
+
     }
 }

--- a/src/main/java/fi/dy/masa/tweakeroo/event/WorldLoadListener.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/event/WorldLoadListener.java
@@ -2,7 +2,6 @@ package fi.dy.masa.tweakeroo.event;
 
 import javax.annotation.Nullable;
 
-import fi.dy.masa.tweakeroo.config.Configs;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.world.ClientWorld;
 import fi.dy.masa.malilib.interfaces.IWorldLoadListener;

--- a/src/main/java/fi/dy/masa/tweakeroo/event/WorldLoadListener.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/event/WorldLoadListener.java
@@ -17,9 +17,5 @@ public class WorldLoadListener implements IWorldLoadListener
         FeatureToggle.TWEAK_FREE_CAMERA.setBooleanValue(false);
         FeatureToggle.TWEAK_FREE_CAMERA_MOTION.setBooleanValue(false);
 
-        // Quick and dirty fix to ensure IValueChangeCallback using callbacks are called.
-        FeatureToggle.TWEAK_GAMMA_OVERRIDE.onValueChanged();
-        Configs.Disable.DISABLE_SLIME_BLOCK_SLOWDOWN.onValueChanged();
-
     }
 }

--- a/src/main/java/fi/dy/masa/tweakeroo/mixin/MixinMinecraftClient.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/mixin/MixinMinecraftClient.java
@@ -1,5 +1,6 @@
 package fi.dy.masa.tweakeroo.mixin;
 
+import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -120,6 +121,44 @@ public abstract class MixinMinecraftClient implements IMinecraftClientInvoker
                 KeyBinding.setKeyPressed(InputUtil.fromTranslationKey(this.options.keyUse.getBoundKeyTranslationKey()), true);
             }
         }
+    }
+
+    @Inject(method = "handleInputEvents", at = @At(
+            value = "JUMP",
+            opcode = Opcodes.IINC, ordinal=1))
+    private void thirdPersonPerspectiveInversion(CallbackInfo ci) {
+        // consider using data storage instead to store the perspective state
+        // not sure on how best to solve code duplication
+
+        if (this.options.perspective == 2) {
+
+            InputUtil.Key keyRight = InputUtil.fromTranslationKey(this.options.keyRight.getBoundKeyTranslationKey());
+            InputUtil.Key keyLeft = InputUtil.fromTranslationKey(this.options.keyLeft.getBoundKeyTranslationKey());
+
+            InputUtil.Key keyForward = InputUtil.fromTranslationKey(this.options.keyForward.getBoundKeyTranslationKey());
+            InputUtil.Key keyBack = InputUtil.fromTranslationKey(this.options.keyBack.getBoundKeyTranslationKey());
+
+            this.options.keyRight.setBoundKey(keyLeft);
+            this.options.keyLeft.setBoundKey(keyRight);
+
+            this.options.keyForward.setBoundKey(keyBack);
+            this.options.keyBack.setBoundKey(keyForward);
+
+        } else if (this.options.perspective == 3) {
+
+            InputUtil.Key keyRight = InputUtil.fromTranslationKey(this.options.keyRight.getBoundKeyTranslationKey());
+            InputUtil.Key keyLeft = InputUtil.fromTranslationKey(this.options.keyLeft.getBoundKeyTranslationKey());
+
+            InputUtil.Key keyForward = InputUtil.fromTranslationKey(this.options.keyForward.getBoundKeyTranslationKey());
+            InputUtil.Key keyBack = InputUtil.fromTranslationKey(this.options.keyBack.getBoundKeyTranslationKey());
+
+            this.options.keyRight.setBoundKey(keyLeft);
+            this.options.keyLeft.setBoundKey(keyRight);
+
+            this.options.keyForward.setBoundKey(keyBack);
+            this.options.keyBack.setBoundKey(keyForward);
+        }
+        KeyBinding.updateKeysByCode();
     }
 
     @ModifyConstant(method = "handleProfilerKeyPress", constant = @Constant(intValue = 46), require = 0, allow = 1)


### PR DESCRIPTION
Bit of a messy branch, multiple things going on.


1. Fix to TWEAK_GAMMA_OVERRIDE and DISABLE_SLIME_BLOCK_SLOWDOWN settings not persisting when reloading game.
Related to issue https://github.com/maruohon/malilib/issues/25
Changed the JSON loading to use the setter, similarly to in https://github.com/maruohon/malilib/pull/26

2. Really bad version of TWEAK_THIRDPERSON_INVERT added, inverts the controls when changing to third person self facing camera. Code duplication and should probably store the perspective somewhere or be injected in a different location.

3. Small change to CARPET_ACCURATE_PLACEMENT_PROTOCOL description for clarity.
4. Added /run/ to .gitignore
