### PR TITLE
Added checks to see if player is spectator or doesn't have an item in hands

### DIFF
--- a/src/main/java/fi/dy/masa/tweakeroo/event/RenderHandler.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/event/RenderHandler.java
@@ -5,6 +5,7 @@ import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.entity.Entity;
 import net.minecraft.item.ItemMap;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.RayTraceResult;
 import fi.dy.masa.malilib.config.values.ActiveMode;
 import fi.dy.masa.malilib.gui.GuiBase;
@@ -97,6 +98,10 @@ public class RenderHandler implements IRenderer
     private void renderOverlays(Minecraft mc, float partialTicks)
     {
         if (FeatureToggle.TWEAK_FLEXIBLE_BLOCK_PLACEMENT.getBooleanValue() &&
+        	!mc.player.isSpectator() &&
+        	!(mc.player.getHeldItem(EnumHand.MAIN_HAND).isEmpty() ||
+        	  mc.player.getHeldItem(EnumHand.OFF_HAND).isEmpty()
+        	 ) &&
             mc.objectMouseOver != null &&
             mc.objectMouseOver.typeOfHit == RayTraceResult.Type.BLOCK &&
             (Hotkeys.FLEXIBLE_BLOCK_PLACEMENT_ROTATION.getKeybind().isKeybindHeld() ||

--- a/src/main/java/fi/dy/masa/tweakeroo/event/RenderHandler.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/event/RenderHandler.java
@@ -3,6 +3,7 @@ package fi.dy.masa.tweakeroo.event;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.entity.Entity;
+import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemMap;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumHand;
@@ -99,9 +100,14 @@ public class RenderHandler implements IRenderer
     {
         if (FeatureToggle.TWEAK_FLEXIBLE_BLOCK_PLACEMENT.getBooleanValue() &&
         	!mc.player.isSpectator() &&
-        	(!mc.player.getHeldItem(EnumHand.MAIN_HAND).isEmpty() ||
-        	 !mc.player.getHeldItem(EnumHand.OFF_HAND).isEmpty()
-        	) &&
+        	(
+              (!mc.player.getHeldItem(EnumHand.MAIN_HAND).isEmpty() && 
+               (mc.player.getHeldItem(EnumHand.MAIN_HAND).getItem() instanceof ItemBlock) 
+              ) ||
+              (!mc.player.getHeldItem(EnumHand.OFF_HAND).isEmpty() && 
+               (mc.player.getHeldItem(EnumHand.OFF_HAND).getItem() instanceof ItemBlock)
+              )
+            ) &&
             mc.objectMouseOver != null &&
             mc.objectMouseOver.typeOfHit == RayTraceResult.Type.BLOCK &&
             (Hotkeys.FLEXIBLE_BLOCK_PLACEMENT_ROTATION.getKeybind().isKeybindHeld() ||

--- a/src/main/java/fi/dy/masa/tweakeroo/event/RenderHandler.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/event/RenderHandler.java
@@ -99,9 +99,9 @@ public class RenderHandler implements IRenderer
     {
         if (FeatureToggle.TWEAK_FLEXIBLE_BLOCK_PLACEMENT.getBooleanValue() &&
         	!mc.player.isSpectator() &&
-        	!(mc.player.getHeldItem(EnumHand.MAIN_HAND).isEmpty() ||
-        	  mc.player.getHeldItem(EnumHand.OFF_HAND).isEmpty()
-        	 ) &&
+        	(!mc.player.getHeldItem(EnumHand.MAIN_HAND).isEmpty() ||
+        	 !mc.player.getHeldItem(EnumHand.OFF_HAND).isEmpty()
+        	) &&
             mc.objectMouseOver != null &&
             mc.objectMouseOver.typeOfHit == RayTraceResult.Type.BLOCK &&
             (Hotkeys.FLEXIBLE_BLOCK_PLACEMENT_ROTATION.getKeybind().isKeybindHeld() ||


### PR DESCRIPTION
Added those checks to the renderer of the flexible block placement to prevent the overlay from rendering in those cases.
I needed it for my sanity.

I couldn't actually test it from master since Gradle complained about some mixin, but Eclipse says it's correct.
The equivalent (or what I think is the equivalent) for Fabric (see altrisi@c419e2f0c76f7a2480b2456b93da0a2c6f798b7f) builds and works correctly (tested in last 1.16 branch, mc 1.16.1).