### PR TITLE
fix npe with freecam

### DIFF
--- a/src/main/java/fi/dy/masa/tweakeroo/util/CameraEntity.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/util/CameraEntity.java
@@ -194,4 +194,7 @@ public class CameraEntity extends ClientPlayerEntity
     {
         camera = null;
     }
+    
+    @Override
+    protected void autoJump(float dx, float dz) {}
 }


### PR DESCRIPTION
mojang appears to have added autojump to move in 1.16 and since autojump is "on" for this entity (private in clientPlayerEntity) and input's never set, it causes an NPE.