### PR TITLE
Fix 20w46a crash when loading world.

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -12,9 +12,9 @@ mod_version = 0.10.0-dev
 malilib_version = 0.10.0-dev.21+beta.2
 
 # Minecraft, Fabric and mappings versions
-minecraft_version_out = 1.17-snap-20w45a
-minecraft_version = 20w45a
-mappings_version = 20w45a+build.31
+minecraft_version_out = 1.17-snap-20w46a
+minecraft_version = 20w46a
+mappings_version = 20w46a+build.23
 
-fabric_loader_version = 0.10.6+build.214
+fabric_loader_version = 0.10.8
 mod_menu_version = 1.15.0+build.1

--- a/build.properties
+++ b/build.properties
@@ -12,9 +12,9 @@ mod_version = 0.10.0-dev
 malilib_version = 0.10.0-dev.21+beta.2
 
 # Minecraft, Fabric and mappings versions
-minecraft_version_out = 1.17-snap-20w45a
-minecraft_version = 20w45a
-mappings_version = 20w45a+build.31
+minecraft_version_out = 1.17-snap-20w46a
+minecraft_version = 20w46a
+mappings_version = 20w46a+build.23
 
 fabric_loader_version = 0.10.6+build.214
 mod_menu_version = 1.15.0+build.1

--- a/src/main/java/fi/dy/masa/tweakeroo/mixin/MixinCommandBlockScreen.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/mixin/MixinCommandBlockScreen.java
@@ -1,6 +1,8 @@
 package fi.dy.masa.tweakeroo.mixin;
 
 import java.util.Arrays;
+
+import net.minecraft.client.gui.widget.CyclingButtonWidget;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -8,6 +10,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import net.minecraft.block.entity.CommandBlockBlockEntity;
+import net.minecraft.block.entity.CommandBlockBlockEntity.Type;
 import net.minecraft.client.gui.screen.ingame.AbstractCommandBlockScreen;
 import net.minecraft.client.gui.screen.ingame.CommandBlockScreen;
 import net.minecraft.client.gui.widget.ButtonWidget;
@@ -29,12 +32,12 @@ public abstract class MixinCommandBlockScreen extends AbstractCommandBlockScreen
     @Final
     private CommandBlockBlockEntity blockEntity;
 
-    @Shadow private ButtonWidget modeButton;
-    @Shadow private ButtonWidget conditionalModeButton;
-    @Shadow private ButtonWidget redstoneTriggerButton;
+    @Shadow private CyclingButtonWidget<Type> modeButton;
+    @Shadow private CyclingButtonWidget<Boolean> conditionalModeButton;
+    @Shadow private CyclingButtonWidget<Boolean> redstoneTriggerButton;
 
     private TextFieldWidget textFieldName;
-    private ButtonWidget buttonUpdateExec;
+    private CyclingButtonWidget<Boolean> buttonUpdateExec;
     private boolean updateExecValue;
     private String lastName = "";
 
@@ -76,17 +79,18 @@ public abstract class MixinCommandBlockScreen extends AbstractCommandBlockScreen
 
             this.updateExecValue = MiscUtils.getUpdateExec(this.blockEntity);
 
-            str = getDisplayStringForCurrentStatus(this.updateExecValue);
-            width = this.textRenderer.getWidth(str) + 10;
+            Text strOn = new TranslatableText("tweakeroo.gui.button.misc.command_block.update_execution.on");
+            Text strOff = new TranslatableText("tweakeroo.gui.button.misc.command_block.update_execution.off");
+            width = this.textRenderer.getWidth(strOff) + 10;
 
-            this.buttonUpdateExec = new ButtonWidget(x2 + widthBtn + 4, y, width, 20, str, (button) ->
+            this.buttonUpdateExec = CyclingButtonWidget.method_32607(strOn, strOff).method_32616().value(this.updateExecValue).build(x2 + widthBtn + 4, y, width, 20, new TranslatableText("tweakeroo.gui.button.misc.command_block.update_execution.looping"), (button, boolean_) ->
             {
-                this.updateExecValue = ! this.updateExecValue;
+                this.updateExecValue = boolean_;
                 MiscUtils.setUpdateExec(this.blockEntity, this.updateExecValue);
 
-                Text strBtn = getDisplayStringForCurrentStatus(this.updateExecValue);
-                button.setMessage(strBtn);
-                button.setWidth(this.textRenderer.getWidth(strBtn) + 10);
+                //Text strBtn = getDisplayStringForCurrentStatus(this.updateExecValue);
+                //button.setMessage(strBtn);
+                //button.setWidth(this.textRenderer.getWidth(strBtn) + 10);
 
                 String cmd = String.format("/data merge block %d %d %d {\"UpdateLastExecution\":%s}",
                         pos.getX(), pos.getY(), pos.getZ(), this.updateExecValue ? "1b" : "0b");

--- a/src/main/resources/assets/tweakeroo/lang/en_us.json
+++ b/src/main/resources/assets/tweakeroo/lang/en_us.json
@@ -10,7 +10,9 @@
     "tweakeroo.gui.button.config_gui.tweak_toggles": "Tweak Toggles",
 
     "tweakeroo.gui.button.misc.command_block.set_name": "Set name",
-    "tweakeroo.gui.button.misc.command_block.update_execution": "Loops: %s",
+    "tweakeroo.gui.button.misc.command_block.update_execution.on": "Loops: on",
+    "tweakeroo.gui.button.misc.command_block.update_execution.off": "Loops: off",
+    "tweakeroo.gui.button.misc.command_block.update_execution.looping": "Looping",
 
     "tweakeroo.gui.button.misc.command_block.hover.update_execution": "Whether or not multiple triggers per game tick are allowed",
 


### PR DESCRIPTION
Updated MixinCommandBlockScreen.java

Tested using `minecraft_version_out` as `1.17-snap-20w45a` on `build.properties`

Tested with `fabric_loader_version` as `0.10.8` on `build.properties`

Not compatible with older minecraft versions.
