### PR TITLE
Free Camera: Fix player rendering with OptiFine

### DIFF
--- a/src/main/java/fi/dy/masa/tweakeroo/mixin/MixinWorldRenderer.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/mixin/MixinWorldRenderer.java
@@ -47,8 +47,8 @@ public abstract class MixinWorldRenderer
         }
     }
 
-    @Inject(method = "render", at = @At(value = "INVOKE",
-            target = "Lnet/minecraft/client/network/ClientPlayerEntity;isSpectator()Z"))
+    @Inject(method = "render", at = @At(value = "INVOKE_STRING",
+            target = "Lnet/minecraft/util/profiler/Profiler;swap(Ljava/lang/String;)V", args = "ldc=terrain_setup"))
     private void preSetupTerrain(net.minecraft.client.util.math.MatrixStack matrixStack, float partialTicks, long limitTime, boolean renderBlockOutline, Camera camera, GameRenderer renderer, LightmapTextureManager lightmap, Matrix4f matrix4f, CallbackInfo ci)
     {
         if (FeatureToggle.TWEAK_FREE_CAMERA.getBooleanValue())
@@ -57,17 +57,9 @@ public abstract class MixinWorldRenderer
         }
     }
 
-    @Inject(method = "render", at = @At(value = "INVOKE", shift = At.Shift.AFTER,
-            target = "Lnet/minecraft/client/render/WorldRenderer;setupTerrain(" +
-                     "Lnet/minecraft/client/render/Camera;" +
-                     "Lnet/minecraft/client/render/Frustum;ZIZ)V"))
+    @Inject(method = "render", at = @At(value = "INVOKE_STRING",
+            target = "Lnet/minecraft/util/profiler/Profiler;swap(Ljava/lang/String;)V", args = "ldc=updatechunks"))
     private void postSetupTerrain(net.minecraft.client.util.math.MatrixStack matrixStack, float partialTicks, long limitTime, boolean renderBlockOutline, Camera camera, GameRenderer renderer, LightmapTextureManager lightmap, Matrix4f matrix4f, CallbackInfo ci)
-    {
-        CameraUtils.setFreeCameraSpectator(false);
-    }
-
-    @Inject(method = "render", at = @At("RETURN"))
-    private void postSetupTerrainOptifineFallback(net.minecraft.client.util.math.MatrixStack matrixStack, float partialTicks, long limitTime, boolean renderBlockOutline, Camera camera, GameRenderer renderer, LightmapTextureManager lightmap, Matrix4f matrix4f, CallbackInfo ci)
     {
         CameraUtils.setFreeCameraSpectator(false);
     }


### PR DESCRIPTION
At some point during the 1.16.4/5 life cycle OptiFine added an extra check to make sure the client's player is always drawn if it isn't in spectator mode, which is where the need for `postSetupTerrainOptifineFallback` came from (as this check comes long after the `setupTerrain` call). It works out easier to effectively sandwich above and below the `setupTerrain` call to fake being in spectator mode because that avoids any future issues were OptiFine to call `AbstractClientPlayerEntity#isSpectator()` any more, alongside remaining compatible with the older versions which don't.