### PR TITLE
Fixes other mods who also uses who also work with chat messages

### DIFF
--- a/src/main/java/fi/dy/masa/tweakeroo/mixin/MixinChatHud.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/mixin/MixinChatHud.java
@@ -7,7 +7,7 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 import fi.dy.masa.tweakeroo.config.FeatureToggle;
 import fi.dy.masa.tweakeroo.util.MiscUtils;
 
-@Mixin(net.minecraft.client.gui.hud.ChatHud.class)
+@Mixin(value = net.minecraft.client.gui.hud.ChatHud.class, priority = 1100)
 public abstract class MixinChatHud extends net.minecraft.client.gui.DrawableHelper
 {
     @ModifyVariable(method = "addMessage(Lnet/minecraft/text/Text;I)V", at = @At("HEAD"), argsOnly = true)


### PR DESCRIPTION
Adds priority to mixin so other mods will still be able to read the vanilla chat message