### PR TITLE
Allow defining a different overlay color for flexible placement when used in adjacent mode

### DIFF
--- a/src/main/java/fi/dy/masa/tweakeroo/config/Configs.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/config/Configs.java
@@ -59,6 +59,7 @@ public class Configs
         public static final IntegerConfig FAST_RIGHT_CLICK_COUNT                        = new IntegerConfig("fastRightClickCount", 2, 1, 64);
         public static final IntegerConfig FILL_CLONE_LIMIT                              = new IntegerConfig("fillCloneLimit", 10000000, 1, 1000000000);
         public static final ColorConfig FLEXIBLE_PLACEMENT_OVERLAY_COLOR                = new ColorConfig("flexibleBlockPlacementOverlayColor", "#C03030F0");
+        public static final ColorConfig FLEXIBLE_PLACEMENT_ADJACENT_OVERLAY_COLOR       = new ColorConfig("flexibleBlockPlacementAdjacentOverlayColor", "#C03030F0");
         public static final DoubleConfig FLY_SPEED_PRESET_1                             = new DoubleConfig("flySpeedPreset1", 0.01, 0, 4);
         public static final DoubleConfig FLY_SPEED_PRESET_2                             = new DoubleConfig("flySpeedPreset2", 0.064, 0, 4);
         public static final DoubleConfig FLY_SPEED_PRESET_3                             = new DoubleConfig("flySpeedPreset3", 0.128, 0, 4);
@@ -136,6 +137,7 @@ public class Configs
                 FAST_RIGHT_CLICK_COUNT,
                 FILL_CLONE_LIMIT,
                 FLEXIBLE_PLACEMENT_OVERLAY_COLOR,
+                FLEXIBLE_PLACEMENT_ADJACENT_OVERLAY_COLOR,
                 FLY_SPEED_PRESET_1,
                 FLY_SPEED_PRESET_2,
                 FLY_SPEED_PRESET_3,

--- a/src/main/java/fi/dy/masa/tweakeroo/event/RenderHandler.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/event/RenderHandler.java
@@ -121,6 +121,11 @@ public class RenderHandler implements PostGameOverlayRenderer, PostItemTooltipRe
             fi.dy.masa.malilib.render.RenderUtils.setupBlend();
 
             Color4f color = Configs.Generic.FLEXIBLE_PLACEMENT_OVERLAY_COLOR.getColor();
+            if(Hotkeys.FLEXIBLE_BLOCK_PLACEMENT_ADJACENT.getKeyBind().isKeyBindHeld())
+            {
+                Color4f color = Configs.Generic.FLEXIBLE_PLACEMENT_ADJACENT_OVERLAY_COLOR.getColor();
+            }
+            
 
             fi.dy.masa.malilib.render.RenderUtils.renderBlockTargetingOverlay(
                     entity,

--- a/src/main/java/fi/dy/masa/tweakeroo/event/RenderHandler.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/event/RenderHandler.java
@@ -123,7 +123,7 @@ public class RenderHandler implements PostGameOverlayRenderer, PostItemTooltipRe
             Color4f color = Configs.Generic.FLEXIBLE_PLACEMENT_OVERLAY_COLOR.getColor();
             if(Hotkeys.FLEXIBLE_BLOCK_PLACEMENT_ADJACENT.getKeyBind().isKeyBindHeld())
             {
-                Color4f color = Configs.Generic.FLEXIBLE_PLACEMENT_ADJACENT_OVERLAY_COLOR.getColor();
+                color = Configs.Generic.FLEXIBLE_PLACEMENT_ADJACENT_OVERLAY_COLOR.getColor();
             }
             
 

--- a/src/main/resources/assets/tweakeroo/lang/en_us.lang
+++ b/src/main/resources/assets/tweakeroo/lang/en_us.lang
@@ -21,6 +21,7 @@ tweakeroo.config.comment.fastplacementrememberorientation=If enabled, then the F
 tweakeroo.config.comment.fastrightclickcount=The number of right clicks to do per game tick when\nthe 'Fast Right Click' tweak is enabled and the use\nbutton (right click) is held down.
 tweakeroo.config.comment.fillclonelimit=The new /fill and /clone block limit in single player,\nif the 'Fill/Clone Limit Override' tweak is enabled.
 tweakeroo.config.comment.flexibleblockplacementoverlaycolor=The color of the currently pointed at\nregion in the Flexible Block Placement overlay.
+tweakeroo.config.comment.flexibleblockplacementadjacentoverlaycolor=The color of the currently pointed at\nregion in the Flexible Block Placement overlay when used in adjacent mode.
 tweakeroo.config.comment.flyspeedpreset1=The fly speed for preset 1.
 tweakeroo.config.comment.flyspeedpreset2=The fly speed for preset 2.
 tweakeroo.config.comment.flyspeedpreset3=The fly speed for preset 3.


### PR DESCRIPTION
I would find it very useful to get a quick visual indication of which mode I'm currently in, as I'm not using the feature all that often and never can quite remember 100% which of the two similar hotkeys I'm using is which mode. Having one blue and the other red would make the feature even more valuable to me, so I tried adding it myself - I only did this via Github's web interface though, and I never developed a Minecraft mod before, so I'm not sure if I actually got all the places that needed changing. Happy to work more on it if you're open to adding the feature but it's not good to go in that state, just let me know. :)