### PR TITLE
Disable Honey Slowdown and Jump

### DIFF
--- a/src/main/java/fi/dy/masa/tweakeroo/config/Callbacks.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/config/Callbacks.java
@@ -37,6 +37,7 @@ public class Callbacks
     {
         FeatureToggle.TWEAK_GAMMA_OVERRIDE.setValueChangeCallback(new FeatureCallbackGamma(FeatureToggle.TWEAK_GAMMA_OVERRIDE, mc));
         Configs.Disable.DISABLE_SLIME_BLOCK_SLOWDOWN.setValueChangeCallback(new FeatureCallbackSlime(Configs.Disable.DISABLE_SLIME_BLOCK_SLOWDOWN));
+        Configs.Disable.DISABLE_HONEY_BLOCK_SLOWDOWN.setValueChangeCallback(new FeatureCallbackHoney(Configs.Disable.DISABLE_HONEY_BLOCK_SLOWDOWN));
 
         FeatureToggle.TWEAK_FAST_BLOCK_PLACEMENT.getKeybind().setCallback(new KeyCallbackToggleFastMode(FeatureToggle.TWEAK_FAST_BLOCK_PLACEMENT));
         FeatureToggle.TWEAK_FAST_BLOCK_PLACEMENT.setValueChangeCallback((cfg) -> {
@@ -191,6 +192,38 @@ public class Callbacks
             else
             {
                 ((IMixinAbstractBlock) Blocks.SLIME_BLOCK).setFriction((float) Configs.Internal.SLIME_BLOCK_SLIPPERINESS_ORIGINAL.getDoubleValue());
+            }
+        }
+    }
+
+    public static class FeatureCallbackHoney implements IValueChangeCallback<ConfigBoolean>
+    {
+        public FeatureCallbackHoney(ConfigBoolean feature)
+        {
+            Configs.Internal.HONEY_BLOCK_VELOCITY_ORIGINAL.setDoubleValue(Blocks.HONEY_BLOCK.getVelocityMultiplier());
+            Configs.Internal.HONEY_BLOCK_JUMP_ORIGINAL.setDoubleValue(Blocks.HONEY_BLOCK.getJumpVelocityMultiplier());
+
+            // If the feature is enabled on game launch, apply the overridden value here
+            if (feature.getBooleanValue())
+            {
+                ((IMixinAbstractBlock) Blocks.HONEY_BLOCK).setVelocity(Blocks.STONE.getVelocityMultiplier());
+                ((IMixinAbstractBlock) Blocks.HONEY_BLOCK).setJumpVelocity(Blocks.STONE.getJumpVelocityMultiplier());
+            }
+        }
+
+        @Override
+        public void onValueChanged(ConfigBoolean config)
+        {
+            IMixinAbstractBlock honey = ((IMixinAbstractBlock) Blocks.HONEY_BLOCK);
+            if (config.getBooleanValue())
+            {
+                honey.setVelocity(Blocks.STONE.getVelocityMultiplier());
+                honey.setJumpVelocity(Blocks.STONE.getJumpVelocityMultiplier());
+            }
+            else
+            {
+                honey.setVelocity((float) Configs.Internal.HONEY_BLOCK_VELOCITY_ORIGINAL.getDoubleValue());
+                honey.setJumpVelocity((float) Configs.Internal.HONEY_BLOCK_JUMP_ORIGINAL.getDoubleValue());
             }
         }
     }

--- a/src/main/java/fi/dy/masa/tweakeroo/config/Callbacks.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/config/Callbacks.java
@@ -37,7 +37,8 @@ public class Callbacks
     {
         FeatureToggle.TWEAK_GAMMA_OVERRIDE.setValueChangeCallback(new FeatureCallbackGamma(FeatureToggle.TWEAK_GAMMA_OVERRIDE, mc));
         Configs.Disable.DISABLE_SLIME_BLOCK_SLOWDOWN.setValueChangeCallback(new FeatureCallbackSlime(Configs.Disable.DISABLE_SLIME_BLOCK_SLOWDOWN));
-        Configs.Disable.DISABLE_HONEY_BLOCK_SLOWDOWN.setValueChangeCallback(new FeatureCallbackHoney(Configs.Disable.DISABLE_HONEY_BLOCK_SLOWDOWN));
+        Configs.Disable.DISABLE_HONEY_BLOCK_SLOWDOWN.setValueChangeCallback(new FeatureCallbackHoneyVelocity(Configs.Disable.DISABLE_HONEY_BLOCK_SLOWDOWN));
+        Configs.Disable.DISABLE_HONEY_BLOCK_JUMP.setValueChangeCallback(new FeatureCallbackHoneyJump(Configs.Disable.DISABLE_HONEY_BLOCK_JUMP));
 
         FeatureToggle.TWEAK_FAST_BLOCK_PLACEMENT.getKeybind().setCallback(new KeyCallbackToggleFastMode(FeatureToggle.TWEAK_FAST_BLOCK_PLACEMENT));
         FeatureToggle.TWEAK_FAST_BLOCK_PLACEMENT.setValueChangeCallback((cfg) -> {
@@ -196,17 +197,42 @@ public class Callbacks
         }
     }
 
-    public static class FeatureCallbackHoney implements IValueChangeCallback<ConfigBoolean>
+    public static class FeatureCallbackHoneyVelocity implements IValueChangeCallback<ConfigBoolean>
     {
-        public FeatureCallbackHoney(ConfigBoolean feature)
+        public FeatureCallbackHoneyVelocity(ConfigBoolean feature)
         {
             Configs.Internal.HONEY_BLOCK_VELOCITY_ORIGINAL.setDoubleValue(Blocks.HONEY_BLOCK.getVelocityMultiplier());
-            Configs.Internal.HONEY_BLOCK_JUMP_ORIGINAL.setDoubleValue(Blocks.HONEY_BLOCK.getJumpVelocityMultiplier());
 
             // If the feature is enabled on game launch, apply the overridden value here
             if (feature.getBooleanValue())
             {
                 ((IMixinAbstractBlock) Blocks.HONEY_BLOCK).setVelocity(Blocks.STONE.getVelocityMultiplier());
+            }
+        }
+
+        @Override
+        public void onValueChanged(ConfigBoolean config)
+        {
+            if (config.getBooleanValue())
+            {
+                ((IMixinAbstractBlock) Blocks.HONEY_BLOCK).setVelocity(Blocks.STONE.getVelocityMultiplier());
+            }
+            else
+            {
+                ((IMixinAbstractBlock) Blocks.HONEY_BLOCK).setVelocity((float) Configs.Internal.HONEY_BLOCK_VELOCITY_ORIGINAL.getDoubleValue());
+            }
+        }
+    }
+
+    public static class FeatureCallbackHoneyJump implements IValueChangeCallback<ConfigBoolean>
+    {
+        public FeatureCallbackHoneyJump(ConfigBoolean feature)
+        {
+            Configs.Internal.HONEY_BLOCK_JUMP_ORIGINAL.setDoubleValue(Blocks.HONEY_BLOCK.getJumpVelocityMultiplier());
+
+            // If the feature is enabled on game launch, apply the overridden value here
+            if (feature.getBooleanValue())
+            {
                 ((IMixinAbstractBlock) Blocks.HONEY_BLOCK).setJumpVelocity(Blocks.STONE.getJumpVelocityMultiplier());
             }
         }
@@ -214,16 +240,13 @@ public class Callbacks
         @Override
         public void onValueChanged(ConfigBoolean config)
         {
-            IMixinAbstractBlock honey = ((IMixinAbstractBlock) Blocks.HONEY_BLOCK);
             if (config.getBooleanValue())
             {
-                honey.setVelocity(Blocks.STONE.getVelocityMultiplier());
-                honey.setJumpVelocity(Blocks.STONE.getJumpVelocityMultiplier());
+                ((IMixinAbstractBlock) Blocks.HONEY_BLOCK).setJumpVelocity(Blocks.STONE.getJumpVelocityMultiplier());
             }
             else
             {
-                honey.setVelocity((float) Configs.Internal.HONEY_BLOCK_VELOCITY_ORIGINAL.getDoubleValue());
-                honey.setJumpVelocity((float) Configs.Internal.HONEY_BLOCK_JUMP_ORIGINAL.getDoubleValue());
+                ((IMixinAbstractBlock) Blocks.HONEY_BLOCK).setJumpVelocity((float) Configs.Internal.HONEY_BLOCK_JUMP_ORIGINAL.getDoubleValue());
             }
         }
     }

--- a/src/main/java/fi/dy/masa/tweakeroo/config/Configs.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/config/Configs.java
@@ -249,6 +249,7 @@ public class Configs implements IConfigHandler
         public static final ConfigBooleanHotkeyed       DISABLE_SIGN_GUI                = new ConfigBooleanHotkeyed("disableSignGui",                       false, "", "Prevent the Sign edit GUI from opening");
         public static final ConfigBooleanHotkeyed       DISABLE_SLIME_BLOCK_SLOWDOWN    = new ConfigBooleanHotkeyed("disableSlimeBlockSlowdown",            false, "", "Removes the slowdown from walking on Slime Blocks.\n(This is originally from usefulmod by nessie.)");
         public static final ConfigBooleanHotkeyed       DISABLE_HONEY_BLOCK_SLOWDOWN    = new ConfigBooleanHotkeyed("disableHoneyBlockSlowdown",            false, "", "Removes the slowdown from walking on Honey Blocks.");
+        public static final ConfigBooleanHotkeyed       DISABLE_HONEY_BLOCK_JUMP        = new ConfigBooleanHotkeyed("disableHoneyBlockJumpModifier",        false, "", "Removes the stickness for jumping on Honey Blocks.");
         public static final ConfigBooleanHotkeyed       DISABLE_TILE_ENTITY_RENDERING   = new ConfigBooleanHotkeyed("disableTileEntityRendering",           false, "", "Prevents all TileEntity renderers from rendering");
         public static final ConfigBooleanHotkeyed       DISABLE_TILE_ENTITY_TICKING     = new ConfigBooleanClient  ("disableTileEntityTicking",             false, "", "Prevent all TileEntities from getting ticked");
         public static final ConfigBooleanHotkeyed       DISABLE_VILLAGER_TRADE_LOCKING  = new ConfigBooleanClient  ("disableVillagerTradeLocking",          false, "", "Prevents villager trades from ever locking, by always incrementing\nthe max uses as well when the recipe uses is incremented");
@@ -284,6 +285,7 @@ public class Configs implements IConfigHandler
                 DISABLE_SIGN_GUI,
                 DISABLE_SLIME_BLOCK_SLOWDOWN,
                 DISABLE_HONEY_BLOCK_SLOWDOWN,
+                DISABLE_HONEY_BLOCK_JUMP,
                 DISABLE_TILE_ENTITY_RENDERING,
                 DISABLE_TILE_ENTITY_TICKING,
                 DISABLE_VILLAGER_TRADE_LOCKING,

--- a/src/main/java/fi/dy/masa/tweakeroo/config/Configs.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/config/Configs.java
@@ -248,6 +248,7 @@ public class Configs implements IConfigHandler
         public static final ConfigBooleanHotkeyed       DISABLE_RENDER_DISTANCE_FOG     = new ConfigBooleanHotkeyed("disableRenderDistanceFog",             false, "", "Disables the fog that increases around the render distance");
         public static final ConfigBooleanHotkeyed       DISABLE_SIGN_GUI                = new ConfigBooleanHotkeyed("disableSignGui",                       false, "", "Prevent the Sign edit GUI from opening");
         public static final ConfigBooleanHotkeyed       DISABLE_SLIME_BLOCK_SLOWDOWN    = new ConfigBooleanHotkeyed("disableSlimeBlockSlowdown",            false, "", "Removes the slowdown from walking on Slime Blocks.\n(This is originally from usefulmod by nessie.)");
+        public static final ConfigBooleanHotkeyed       DISABLE_HONEY_BLOCK_SLOWDOWN    = new ConfigBooleanHotkeyed("disableHoneyBlockSlowdown",            false, "", "Removes the slowdown from walking on Honey Blocks.");
         public static final ConfigBooleanHotkeyed       DISABLE_TILE_ENTITY_RENDERING   = new ConfigBooleanHotkeyed("disableTileEntityRendering",           false, "", "Prevents all TileEntity renderers from rendering");
         public static final ConfigBooleanHotkeyed       DISABLE_TILE_ENTITY_TICKING     = new ConfigBooleanClient  ("disableTileEntityTicking",             false, "", "Prevent all TileEntities from getting ticked");
         public static final ConfigBooleanHotkeyed       DISABLE_VILLAGER_TRADE_LOCKING  = new ConfigBooleanClient  ("disableVillagerTradeLocking",          false, "", "Prevents villager trades from ever locking, by always incrementing\nthe max uses as well when the recipe uses is incremented");
@@ -282,6 +283,7 @@ public class Configs implements IConfigHandler
                 DISABLE_RENDER_DISTANCE_FOG,
                 DISABLE_SIGN_GUI,
                 DISABLE_SLIME_BLOCK_SLOWDOWN,
+                DISABLE_HONEY_BLOCK_SLOWDOWN,
                 DISABLE_TILE_ENTITY_RENDERING,
                 DISABLE_TILE_ENTITY_TICKING,
                 DISABLE_VILLAGER_TRADE_LOCKING,
@@ -296,6 +298,8 @@ public class Configs implements IConfigHandler
         public static final ConfigDouble        GAMMA_VALUE_ORIGINAL                = new ConfigDouble      ("gammaValueOriginal", 0, 0, 1, "The original gamma value, before the gamma override was enabled");
         public static final ConfigInteger       HOTBAR_SCROLL_CURRENT_ROW           = new ConfigInteger     ("hotbarScrollCurrentRow", 3, 0, 3, "This is just for the mod internally to track the\n\"current hotbar row\" for the hotbar scrolling feature");
         public static final ConfigDouble        SLIME_BLOCK_SLIPPERINESS_ORIGINAL   = new ConfigDouble      ("slimeBlockSlipperinessOriginal", 0.8, 0, 1, "The original slipperiness value of Slime Blocks");
+        public static final ConfigDouble        HONEY_BLOCK_VELOCITY_ORIGINAL       = new ConfigDouble      ("honeyBlockVelocityOriginal", 0.4, 0, 1, "The original velocity value of Honey Blocks");
+        public static final ConfigDouble        HONEY_BLOCK_JUMP_ORIGINAL           = new ConfigDouble      ("honeyBlockJumpOriginal", 0.5, 0, 1, "The original jump velocity value of Honey Blocks");
         public static final ConfigDouble        SNAP_AIM_LAST_PITCH                 = new ConfigDouble      ("snapAimLastPitch", 0, -135, 135, "The last snapped-to pitch value");
         public static final ConfigDouble        SNAP_AIM_LAST_YAW                   = new ConfigDouble      ("snapAimLastYaw", 0, 0, 360, "The last snapped-to yaw value");
 

--- a/src/main/java/fi/dy/masa/tweakeroo/mixin/IMixinAbstractBlock.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/mixin/IMixinAbstractBlock.java
@@ -8,4 +8,10 @@ public interface IMixinAbstractBlock
 {
     @Accessor("slipperiness")
     void setFriction(float friction);
+
+    @Accessor("velocityMultiplier")
+    void setVelocity(float friction);
+
+    @Accessor("jumpVelocityMultiplier")
+    void setJumpVelocity(float friction);
 }


### PR DESCRIPTION
Enableing TweakNo `disableHoneyBlockSlowdown` will make the player have normal velocity and jump while standing on honey blocks. Simil to TweakNo `disableSlimeBlockSlowdown`

Disableing it will restore default `velocityMultiplier` and `jumpVelocityMultiplier` values