### PR TITLE
Fix the crash caused by `tweakChatPersistentText`

### DIFF
--- a/src/main/java/fi/dy/masa/tweakeroo/mixin/MixinChatScreen.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/mixin/MixinChatScreen.java
@@ -1,6 +1,8 @@
 package fi.dy.masa.tweakeroo.mixin;
 
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.At.Shift;
@@ -21,8 +23,9 @@ public abstract class MixinChatScreen
 {
     @Shadow
     protected TextFieldWidget chatField;
-    @Shadow
-    private String originalChatText;
+
+    @Mutable
+    @Shadow @Final private String originalChatText;
 
     @Inject(method = "removed", at = @At("HEAD"))
     private void storeChatText(CallbackInfo ci)


### PR DESCRIPTION
## When `tweakChatPersistentText` is enabled, if the chat input window is not empty, close the chat window and open it again, the game will crash.
The log of this problem is as follows
<pre>
[13:23:22] [Render thread/FATAL] (Minecraft) Unreported exception thrown!
java.lang.IllegalAccessError: Update to non-static final field net.minecraft.client.gui.screen.ChatScreen.originalChatText attempted from a different method (handler$zzh000$restoreText) than the initializer method <init> 
	at net.minecraft.client.gui.screen.ChatScreen.handler$zzh000$restoreText(ChatScreen.java:541) ~[minecraft-1.17-mapped-net.fabricmc.yarn-1.17+build.1-v2.jar:?]
	at net.minecraft.client.gui.screen.ChatScreen.<init>(ChatScreen.java:31) ~[minecraft-1.17-mapped-net.fabricmc.yarn-1.17+build.1-v2.jar:?]
	at net.minecraft.client.MinecraftClient.openChatScreen(MinecraftClient.java:988) ~[minecraft-1.17-mapped-net.fabricmc.yarn-1.17+build.1-v2.jar:?]
	at net.minecraft.client.MinecraftClient.handleInputEvents(MinecraftClient.java:1916) ~[minecraft-1.17-mapped-net.fabricmc.yarn-1.17+build.1-v2.jar:?]
	at net.minecraft.client.MinecraftClient.tick(MinecraftClient.java:1762) ~[minecraft-1.17-mapped-net.fabricmc.yarn-1.17+build.1-v2.jar:?]
	at net.minecraft.client.MinecraftClient.render(MinecraftClient.java:1125) ~[minecraft-1.17-mapped-net.fabricmc.yarn-1.17+build.1-v2.jar:?]
	at net.minecraft.client.MinecraftClient.run(MinecraftClient.java:746) [minecraft-1.17-mapped-net.fabricmc.yarn-1.17+build.1-v2.jar:?]
	at net.minecraft.client.main.Main.main(Main.java:191) [minecraft-1.17-mapped-net.fabricmc.yarn-1.17+build.1-v2.jar:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:78) ~[?:?]
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
	at java.lang.reflect.Method.invoke(Method.java:567) ~[?:?]
	at net.fabricmc.loader.game.MinecraftGameProvider.launch(MinecraftGameProvider.java:226) [fabric-loader-0.11.3.jar:?]
	at net.fabricmc.loader.launch.knot.Knot.launch(Knot.java:146) [fabric-loader-0.11.3.jar:?]
	at net.fabricmc.loader.launch.knot.KnotClient.main(KnotClient.java:28) [fabric-loader-0.11.3.jar:?]
	at net.fabricmc.devlaunchinjector.Main.main(Main.java:86) [dev-launch-injector-0.2.1+build.8.jar:?]
</pre>