### PR TITLE
Fixed issue 283 and added DISABLE_PATHING as suggested by issue 276

### DIFF
--- a/src/main/java/fi/dy/masa/tweakeroo/config/Configs.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/config/Configs.java
@@ -239,6 +239,7 @@ public class Configs implements IConfigHandler
     {
         public static final ConfigBooleanHotkeyed       DISABLE_ARMOR_STAND_RENDERING   = new ConfigBooleanHotkeyed("disableArmorStandRendering",           false, "", "Disables all Armor Stand entity rendering");
         public static final ConfigBooleanHotkeyed       DISABLE_AXE_STRIPPING           = new ConfigBooleanHotkeyed("disableAxeStripping",                  false, "", "Disables stripping logs with an axe");
+        public static final ConfigBooleanHotkeyed       DISABLE_PATHING                 = new ConfigBooleanHotkeyed("disablePathing",                       false, "", "Disables turning any block into a path block with a shovel");
         public static final ConfigBooleanHotkeyed       DISABLE_BLOCK_BREAK_PARTICLES   = new ConfigBooleanHotkeyed("disableBlockBreakingParticles",        false, "", "Removes the block breaking particles.\n(This is originally from usefulmod by nessie.)");
         public static final ConfigBooleanHotkeyed       DISABLE_DOUBLE_TAP_SPRINT       = new ConfigBooleanHotkeyed("disableDoubleTapSprint",               false, "", "Disables the double-tap-forward-key sprinting");
         public static final ConfigBooleanHotkeyed       DISABLE_BOSS_FOG                = new ConfigBooleanHotkeyed("disableBossFog",                       false, "", "Removes the fog that boss mobs cause");
@@ -276,6 +277,7 @@ public class Configs implements IConfigHandler
         public static final ImmutableList<IHotkeyTogglable> OPTIONS = ImmutableList.of(
                 DISABLE_ARMOR_STAND_RENDERING,
                 DISABLE_AXE_STRIPPING,
+                DISABLE_PATHING,
                 DISABLE_BLOCK_BREAK_PARTICLES,
                 DISABLE_DOUBLE_TAP_SPRINT,
                 DISABLE_BOSS_FOG,

--- a/src/main/java/fi/dy/masa/tweakeroo/config/Configs.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/config/Configs.java
@@ -271,6 +271,7 @@ public class Configs implements IConfigHandler
         public static final ConfigBooleanHotkeyed       DISABLE_VILLAGER_TRADE_LOCKING  = new ConfigBooleanClient  ("disableVillagerTradeLocking",          false, "", "Prevents villager trades from ever locking, by always incrementing\nthe max uses as well when the recipe uses is incremented");
         public static final ConfigBooleanHotkeyed       DISABLE_WALL_UNSPRINT           = new ConfigBooleanHotkeyed("disableWallUnsprint",                  false, "", "Touching a wall doesn't drop you out from sprint mode");
         public static final ConfigBooleanHotkeyed       DISABLE_WORLD_VIEW_BOB          = new ConfigBooleanHotkeyed("disableWorldViewBob",                  false, "", "Disables the view bob wobble effect of the world, but not the hand");
+        public static final ConfigBooleanHotkeyed       DISABLE_AUTO_SWIM               = new ConfigBooleanHotkeyed("disableAutoSwim",                       true, "", "Disables automatic swimming while permanentSprint is on");
 
         public static final ImmutableList<IHotkeyTogglable> OPTIONS = ImmutableList.of(
                 DISABLE_ARMOR_STAND_RENDERING,
@@ -306,7 +307,8 @@ public class Configs implements IConfigHandler
                 DISABLE_TILE_ENTITY_TICKING,
                 DISABLE_VILLAGER_TRADE_LOCKING,
                 DISABLE_WALL_UNSPRINT,
-                DISABLE_WORLD_VIEW_BOB
+                DISABLE_WORLD_VIEW_BOB,
+                DISABLE_AUTO_SWIM
         );
     }
 

--- a/src/main/java/fi/dy/masa/tweakeroo/mixin/MixinClientPlayerEntity.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/mixin/MixinClientPlayerEntity.java
@@ -95,7 +95,8 @@ public abstract class MixinClientPlayerEntity extends AbstractClientPlayerEntity
         if (FeatureToggle.TWEAK_PERMANENT_SPRINT.getBooleanValue() &&
             ! this.isSprinting() && ! this.isUsingItem() && this.input.movementForward >= 0.8F &&
             (this.getHungerManager().getFoodLevel() > 6.0F || this.getAbilities().allowFlying) &&
-            ! this.hasStatusEffect(StatusEffects.BLINDNESS))
+            ! this.hasStatusEffect(StatusEffects.BLINDNESS) &&
+            (! this.isTouchingWater() || (!Configs.Disable.DISABLE_AUTO_SWIM.getBooleanValue() && this.submergedInWater) ))
         {
             this.setSprinting(true);
         }

--- a/src/main/java/fi/dy/masa/tweakeroo/tweaks/PlacementTweaks.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/tweaks/PlacementTweaks.java
@@ -10,12 +10,7 @@ import net.minecraft.client.network.ClientPlayerInteractionManager;
 import net.minecraft.client.world.ClientWorld;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;
-import net.minecraft.item.AxeItem;
-import net.minecraft.item.BlockItem;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemPlacementContext;
-import net.minecraft.item.ItemStack;
-import net.minecraft.item.ItemUsageContext;
+import net.minecraft.item.*;
 import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket;
 import net.minecraft.screen.ScreenHandler;
 import net.minecraft.state.property.DirectionProperty;
@@ -313,6 +308,13 @@ public class PlacementTweaks
         if (Configs.Disable.DISABLE_AXE_STRIPPING.getBooleanValue() &&
             stackPre.getItem() instanceof AxeItem &&
             MiscUtils.isStrippableLog(world, hitResult.getBlockPos()))
+        {
+            return ActionResult.PASS;
+        }
+
+        if(Configs.Disable.DISABLE_PATHING.getBooleanValue() &&
+            stackPre.getItem() instanceof ShovelItem &&
+            MiscUtils.isPathableBlock(world, hitResult.getBlockPos()))
         {
             return ActionResult.PASS;
         }

--- a/src/main/java/fi/dy/masa/tweakeroo/util/MiscUtils.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/util/MiscUtils.java
@@ -10,7 +10,9 @@ import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 import javax.imageio.ImageIO;
+import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
 import net.minecraft.block.MapColor;
 import net.minecraft.block.entity.CommandBlockBlockEntity;
 import net.minecraft.block.entity.SignBlockEntity;
@@ -125,6 +127,12 @@ public class MiscUtils
     {
         BlockState state = world.getBlockState(pos);
         return IMixinAxeItem.tweakeroo_getStrippedBlocks().containsKey(state.getBlock());
+    }
+
+    public static boolean isPathableBlock(World world, BlockPos pos){
+        Block block = world.getBlockState(pos).getBlock();
+
+        return block == Blocks.DIRT || block == Blocks.GRASS_BLOCK || block == Blocks.COARSE_DIRT || block == Blocks.MYCELIUM || block == Blocks.PODZOL || block == Blocks.ROOTED_DIRT;
     }
 
     public static boolean getUpdateExec(CommandBlockBlockEntity te)


### PR DESCRIPTION
**Fixed issue #283**
Automatic sprinting will no longer occur when the Player is in water.

**Added option DISABLE_AUTO_SWIM**
This disables automatically sprinting when submerged in water (ie the swimming animation), as it can be very annoying. Enabled by default

**Added option DISABLE_PATHING**
As suggested by #276