### PR TITLE
Fix incorrect Hit Vector when using Flexible block placement.

### DIFF
--- a/src/main/java/fi/dy/masa/tweakeroo/tweaks/PlacementTweaks.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/tweaks/PlacementTweaks.java
@@ -426,6 +426,7 @@ public class PlacementTweaks
             if (adjacent && hitPart != null && hitPart != HitPart.CENTER)
             {
                 posNew = posNew.offset(sideRotatedIn.getOpposite()).offset(sideIn.getOpposite());
+                hitVec = hitVec.add(Vec3d.of(sideRotatedIn.getOpposite().getVector().add(sideIn.getOpposite().getVector())));
                 handleFlexible = true;
             }
 
@@ -445,6 +446,7 @@ public class PlacementTweaks
             if (offset)
             {
                 posNew = posNew.offset(sideRotatedIn.getOpposite());
+                hitVec = hitVec.add(Vec3d.of(sideRotatedIn.getOpposite().getVector()));
                 handleFlexible = true;
             }
         }


### PR DESCRIPTION
Fixes #398, fixes #338.
When FlexibleBlockPlacement changes the position of a block, update the Hit Vector to match. This should no longer trigger the vanilla anticheat (it at the very least works on paper).

Also fixes issues when the difference between the Hit Vector and new block position causes the accurateBlockPlacement protocol to be off by one, when the block is offset in the X-axis. (This could also trigger a request to rotate a block facing down when you only tried to offset it, which should now also be fixed).