### PR TITLE
bugfix(GammaOverride): Fix the bug that GammaOverride isn't work after restart the game

### DIFF
--- a/src/main/java/fi/dy/masa/tweakeroo/config/Callbacks.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/config/Callbacks.java
@@ -36,7 +36,7 @@ public class Callbacks
 
     public static void init(MinecraftClient mc)
     {
-        FeatureToggle.TWEAK_GAMMA_OVERRIDE.setValueChangeCallback(new FeatureCallbackGamma(FeatureToggle.TWEAK_GAMMA_OVERRIDE, mc));
+        FeatureToggle.TWEAK_GAMMA_OVERRIDE.setValueChangeCallback(new FeatureCallbackGamma(mc));
         Configs.Disable.DISABLE_SLIME_BLOCK_SLOWDOWN.setValueChangeCallback(new FeatureCallbackSlime(Configs.Disable.DISABLE_SLIME_BLOCK_SLOWDOWN));
 
         FeatureToggle.TWEAK_FAST_BLOCK_PLACEMENT.getKeybind().setCallback(new KeyCallbackToggleFastMode(FeatureToggle.TWEAK_FAST_BLOCK_PLACEMENT));
@@ -144,7 +144,7 @@ public class Callbacks
     {
         private final MinecraftClient mc;
 
-        public FeatureCallbackGamma(FeatureToggle feature, MinecraftClient mc)
+        public FeatureCallbackGamma(MinecraftClient mc)
         {
             this.mc = mc;
             double gamma = this.mc.options.getGamma().getValue();
@@ -155,10 +155,12 @@ public class Callbacks
             }
 
             // If the feature is enabled on game launch, apply it here
-            if (feature.getBooleanValue())
-            {
-                this.applyValue(Configs.Generic.GAMMA_OVERRIDE_VALUE.getDoubleValue());
-            }
+//            if (feature.getBooleanValue())
+//            {
+//                this.applyValue(Configs.Generic.GAMMA_OVERRIDE_VALUE.getDoubleValue());
+//            }
+
+            // The config file loaded after Callback.init(), so this code is useless.
         }
 
         @Override

--- a/src/main/java/fi/dy/masa/tweakeroo/config/Configs.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/config/Configs.java
@@ -459,6 +459,11 @@ public class Configs implements IConfigHandler
             // But only if we are currently not in a world, since changing configs also re-loads them when closing the menu.
             FeatureToggle.TWEAK_FREE_CAMERA.setBooleanValue(false);
         }
+        if(FeatureToggle.TWEAK_GAMMA_OVERRIDE.getBooleanValue())
+        {
+            // If the feature is enabled on game launch, apply it here
+            FeatureToggle.TWEAK_GAMMA_OVERRIDE.onValueChanged();
+        }
     }
 
     public static void saveToFile()


### PR DESCRIPTION
**How to preduce the bug:**
- Switch on `GammaOverride` toggle.
- Restart the game.
- `GammaOverride` isn't work.

_Maybe not the best way to fix this bug._

Linked issue: #348
