### PR TITLE
Fix timestamps being added to messages during a refresh

### DIFF
--- a/src/main/java/fi/dy/masa/tweakeroo/mixin/MixinChatHud.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/mixin/MixinChatHud.java
@@ -1,5 +1,7 @@
 package fi.dy.masa.tweakeroo.mixin;
 
+import net.minecraft.client.gui.hud.MessageIndicator;
+import net.minecraft.network.message.MessageSignatureData;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
@@ -18,8 +20,14 @@ public abstract class MixinChatHud
 {
     @ModifyVariable(method = "addMessage(Lnet/minecraft/text/Text;Lnet/minecraft/network/message/MessageSignatureData;ILnet/minecraft/client/gui/hud/MessageIndicator;Z)V",
                     at = @At("HEAD"), argsOnly = true)
-    private Text tweakeroo_addMessageTimestamp(Text componentIn)
+    private Text tweakeroo_addMessageTimestamp(Text componentIn, Text parameterMessage, MessageSignatureData data, int ticks, MessageIndicator indicator, boolean refreshing)
     {
+        // If we're refreshing, we have probably already modified the message, therefore we don't want to do anything.
+        if (refreshing)
+        {
+            return componentIn;
+        }
+
         if (FeatureToggle.TWEAK_CHAT_TIMESTAMP.getBooleanValue())
         {
             MutableText newComponent = Text.literal(MiscUtils.getChatTimestamp() + " ");


### PR DESCRIPTION
Closes #446

As you can see, this fixes the issue with other mods (*read issue #446 for context)
<img width="922" alt="CleanShot 2023-07-14 at 16 46 00@2x" src="https://github.com/maruohon/tweakeroo/assets/71222289/30d369d6-f1ce-4087-b2eb-b2eba1d21b27">
