### PR TITLE
Inject PlacementTweaks.onGameLoop before Thread.yield

### DIFF
--- a/src/main/java/fi/dy/masa/tweakeroo/mixin/MixinMinecraftClient.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/mixin/MixinMinecraftClient.java
@@ -59,7 +59,11 @@ public abstract class MixinMinecraftClient implements IMinecraftClientInvoker
         this.doItemUse();
     }
 
-    @Inject(method = "render", at = @At("RETURN"))
+    @Inject(method = "render", at = @At(
+            value = "INVOKE",
+            ordinal = 2,
+            target = "Lnet/minecraft/util/profiler/Profiler;swap(Ljava/lang/String;)V"))
+    // inject before Thread.yield
     private void onGameLoop(boolean renderWorld, CallbackInfo ci)
     {
         if (this.player != null && this.world != null)


### PR DESCRIPTION
Slightly increases performance by changing the mixin target in `MixinMinecraftClient` from at the tail of `render` to before `Thread.yield` to increase the performance of `MiscTweaks.onGameLoop`.