### PR TITLE
[pre_rewrite/fabric/1.20.x] fix #524 water bucket can't restock due change hotbar packet sent earlier than use packet, in a strange way.

### DIFF
--- a/src/main/java/fi/dy/masa/tweakeroo/mixin/MixinSendPacket.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/mixin/MixinSendPacket.java
@@ -4,8 +4,6 @@ import fi.dy.masa.tweakeroo.util.PendingPackets;
 import net.minecraft.client.network.ClientCommonNetworkHandler;
 import net.minecraft.network.ClientConnection;
 import net.minecraft.network.packet.Packet;
-import net.minecraft.network.packet.c2s.common.KeepAliveC2SPacket;
-import net.minecraft.network.packet.c2s.play.*;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -19,48 +17,10 @@ public class MixinSendPacket {
     @Shadow
     protected ClientConnection connection;
 
-
     @Inject(method = "sendPacket(Lnet/minecraft/network/packet/Packet;)V", at = @At("TAIL"))
-    private void b(Packet<?> packet, CallbackInfo ci) {
+    private void afterSendPacket(Packet<?> packet, CallbackInfo ci) {
         List<Packet<?>> pendingPackets = PendingPackets.getPackets(packet.getClass());
         if (pendingPackets == null) return;
         pendingPackets.forEach(p -> this.connection.send(p));
     }
-
-    @Inject(method = "sendPacket(Lnet/minecraft/network/packet/Packet;)V", at = @At("TAIL"))
-    private void a(Packet<?> packet, CallbackInfo ci) {
-        if (packet instanceof KeepAliveC2SPacket || packet instanceof PlayerMoveC2SPacket || packet instanceof AcknowledgeChunksC2SPacket)
-            return;
-        System.out.println(packet.getClass());
-
-        if (packet instanceof UpdateSelectedSlotC2SPacket p) {
-            System.out.println(p.getSelectedSlot());
-            printTrace();
-        } else if (packet instanceof PlayerInteractBlockC2SPacket p || packet instanceof PlayerInteractItemC2SPacket p2) {
-            printTrace();
-        }
-    }
-
-    private void printTrace() {
-        try {
-            throw new Exception();
-        } catch (Exception e) {e.printStackTrace();}
-    }
 }
-
-
-//[22:05:47] [Render thread/INFO] (Minecraft) [STDOUT]: class net.minecraft.network.packet.c2s.play.PlayerInteractBlockC2SPacket
-//[22:05:47] [Render thread/INFO] (Minecraft) [STDOUT]: class net.minecraft.network.packet.c2s.play.UpdateSelectedSlotC2SPacket
-//[22:05:47] [Render thread/INFO] (Minecraft) [STDOUT]: class net.minecraft.network.packet.c2s.play.PlayerInteractItemC2SPacket 
-// we can found that there are the 2nd Interact packet sent after the 1st swap packet
-// which means we switch the hotbar first, then use the water bucket.
-// so we should switch it later.
-//[22:05:47] [Render thread/INFO] (Minecraft) [STDOUT]: class net.minecraft.network.packet.c2s.play.HandSwingC2SPacket
-//[22:05:47] [Render thread/INFO] (Minecraft) [STDOUT]: class net.minecraft.network.packet.c2s.play.UpdateSelectedSlotC2SPacket
-//[22:05:53] [Render thread/INFO] (Minecraft) [STDOUT]: class net.minecraft.network.packet.c2s.play.ChatMessageC2SPacket
-
-//[22:06:05] [Render thread/INFO] (Minecraft) [STDOUT]: class net.minecraft.network.packet.c2s.play.PlayerInteractBlockC2SPacket
-//[22:06:05] [Render thread/INFO] (Minecraft) [STDOUT]: class net.minecraft.network.packet.c2s.play.UpdateSelectedSlotC2SPacket
-//[22:06:05] [Render thread/INFO] (Minecraft) [STDOUT]: class net.minecraft.network.packet.c2s.play.HandSwingC2SPacket
-//[22:06:05] [Render thread/INFO] (Minecraft) [STDOUT]: class net.minecraft.network.packet.c2s.play.UpdateSelectedSlotC2SPacket
-//[22:06:09] [Render thread/INFO] (Minecraft) [STDOUT]: class net.minecraft.network.packet.c2s.play.ChatMessageC2SPacket

--- a/src/main/java/fi/dy/masa/tweakeroo/mixin/MixinSendPacket.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/mixin/MixinSendPacket.java
@@ -1,0 +1,66 @@
+package fi.dy.masa.tweakeroo.mixin;
+
+import fi.dy.masa.tweakeroo.util.PendingPackets;
+import net.minecraft.client.network.ClientCommonNetworkHandler;
+import net.minecraft.network.ClientConnection;
+import net.minecraft.network.packet.Packet;
+import net.minecraft.network.packet.c2s.common.KeepAliveC2SPacket;
+import net.minecraft.network.packet.c2s.play.*;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.List;
+
+@Mixin(ClientCommonNetworkHandler.class)
+public class MixinSendPacket {
+    @Shadow
+    protected ClientConnection connection;
+
+
+    @Inject(method = "sendPacket(Lnet/minecraft/network/packet/Packet;)V", at = @At("TAIL"))
+    private void b(Packet<?> packet, CallbackInfo ci) {
+        List<Packet<?>> pendingPackets = PendingPackets.getPackets(packet.getClass());
+        if (pendingPackets == null) return;
+        pendingPackets.forEach(p -> this.connection.send(p));
+    }
+
+    @Inject(method = "sendPacket(Lnet/minecraft/network/packet/Packet;)V", at = @At("TAIL"))
+    private void a(Packet<?> packet, CallbackInfo ci) {
+        if (packet instanceof KeepAliveC2SPacket || packet instanceof PlayerMoveC2SPacket || packet instanceof AcknowledgeChunksC2SPacket)
+            return;
+        System.out.println(packet.getClass());
+
+        if (packet instanceof UpdateSelectedSlotC2SPacket p) {
+            System.out.println(p.getSelectedSlot());
+            printTrace();
+        } else if (packet instanceof PlayerInteractBlockC2SPacket p || packet instanceof PlayerInteractItemC2SPacket p2) {
+            printTrace();
+        }
+    }
+
+    private void printTrace() {
+        try {
+            throw new Exception();
+        } catch (Exception e) {e.printStackTrace();}
+    }
+}
+
+
+//[22:05:47] [Render thread/INFO] (Minecraft) [STDOUT]: class net.minecraft.network.packet.c2s.play.PlayerInteractBlockC2SPacket
+//[22:05:47] [Render thread/INFO] (Minecraft) [STDOUT]: class net.minecraft.network.packet.c2s.play.UpdateSelectedSlotC2SPacket
+//[22:05:47] [Render thread/INFO] (Minecraft) [STDOUT]: class net.minecraft.network.packet.c2s.play.PlayerInteractItemC2SPacket 
+// we can found that there are the 2nd Interact packet sent after the 1st swap packet
+// which means we switch the hotbar first, then use the water bucket.
+// so we should switch it later.
+//[22:05:47] [Render thread/INFO] (Minecraft) [STDOUT]: class net.minecraft.network.packet.c2s.play.HandSwingC2SPacket
+//[22:05:47] [Render thread/INFO] (Minecraft) [STDOUT]: class net.minecraft.network.packet.c2s.play.UpdateSelectedSlotC2SPacket
+//[22:05:53] [Render thread/INFO] (Minecraft) [STDOUT]: class net.minecraft.network.packet.c2s.play.ChatMessageC2SPacket
+
+//[22:06:05] [Render thread/INFO] (Minecraft) [STDOUT]: class net.minecraft.network.packet.c2s.play.PlayerInteractBlockC2SPacket
+//[22:06:05] [Render thread/INFO] (Minecraft) [STDOUT]: class net.minecraft.network.packet.c2s.play.UpdateSelectedSlotC2SPacket
+//[22:06:05] [Render thread/INFO] (Minecraft) [STDOUT]: class net.minecraft.network.packet.c2s.play.HandSwingC2SPacket
+//[22:06:05] [Render thread/INFO] (Minecraft) [STDOUT]: class net.minecraft.network.packet.c2s.play.UpdateSelectedSlotC2SPacket
+//[22:06:09] [Render thread/INFO] (Minecraft) [STDOUT]: class net.minecraft.network.packet.c2s.play.ChatMessageC2SPacket

--- a/src/main/java/fi/dy/masa/tweakeroo/util/InventoryUtils.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/util/InventoryUtils.java
@@ -29,6 +29,7 @@ import net.minecraft.item.MiningToolItem;
 import net.minecraft.item.SwordItem;
 import net.minecraft.item.ToolItem;
 import net.minecraft.nbt.NbtCompound;
+import net.minecraft.network.packet.c2s.play.PlayerInteractItemC2SPacket;
 import net.minecraft.network.packet.c2s.play.UpdateSelectedSlotC2SPacket;
 import net.minecraft.registry.Registries;
 import net.minecraft.screen.PlayerScreenHandler;
@@ -806,7 +807,8 @@ public class InventoryUtils
                 if (isHotbarSlot(slotNumber))
                 {
                     inventory.selectedSlot = slotNumber - 36;
-                    mc.getNetworkHandler().sendPacket(new UpdateSelectedSlotC2SPacket(inventory.selectedSlot));
+                    PendingPackets.addPacket(new UpdateSelectedSlotC2SPacket(inventory.selectedSlot), PlayerInteractItemC2SPacket.class);
+//                    mc.getNetworkHandler().sendPacket(new UpdateSelectedSlotC2SPacket(inventory.selectedSlot));
                 }
                 else
                 {

--- a/src/main/java/fi/dy/masa/tweakeroo/util/PendingPackets.java
+++ b/src/main/java/fi/dy/masa/tweakeroo/util/PendingPackets.java
@@ -1,0 +1,29 @@
+package fi.dy.masa.tweakeroo.util;
+
+import net.minecraft.network.packet.Packet;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.*;
+
+public class PendingPackets {
+    private static final Map<Class<?>, List<Packet<?>>> packets = new HashMap<>();
+
+    public static void addPacket(Packet<?> packet, Class<?> after) {
+        if (packets.containsKey(after)) {
+            packets.get(after).add(packet);
+        } else {
+            LinkedList<Packet<?>> p = new LinkedList<>();
+            p.add(packet);
+            packets.put(after, p);
+        }
+    }
+
+    @Nullable
+    public static List<Packet<?>> getPackets(Class<?> currentPacketClass) {
+        if (packets.containsKey(currentPacketClass)) {
+            return packets.remove(currentPacketClass);
+        } else {
+            return null;
+        }
+    }
+}

--- a/src/main/resources/mixins.tweakeroo.json
+++ b/src/main/resources/mixins.tweakeroo.json
@@ -73,7 +73,8 @@
 		"MixinUpdateStructureBlockC2SPacket",
 		"MixinWindow",
 		"MixinWorld",
-		"MixinWorldRenderer"
+		"MixinWorldRenderer",
+		"MixinSendPacket"
 	],
 	"mixinPriority": 990,
 	"injectors": {


### PR DESCRIPTION
related issue: #524
(sorry but I have no idea if there a better way to fix it)